### PR TITLE
GitHub Achievements 가이드 추가

### DIFF
--- a/github_achievements.md
+++ b/github_achievements.md
@@ -1,0 +1,21 @@
+# GitHub Achievements 가이드
+
+GitHub는 다양한 활동에 대해 배지를 제공합니다. 이를 통해 사용자의 참여를 유도하고 재미있는 경험을 제공합니다.
+
+## 인기 있는 배지들
+
+1. **Quickdraw**: 이슈나 PR을 연 후 5분 안에 닫기
+2. **Pull Shark**: Pull Request가 병합됨
+3. **YOLO**: 코드 리뷰 없이 PR 병합하기
+4. **Pair Extraordinaire**: 공동 커밋
+5. **Starstruck**: 저장소가 16개의 별을 받음
+6. **Galaxy Brain**: 2개 이상의 답변이 채택됨
+
+## 배지 획득 팁
+
+- 정기적으로 GitHub에 기여하세요
+- 오픈 소스 프로젝트에 참여하세요
+- 질문에 답변하고 이슈를 해결하세요
+- 다른 개발자와 협업하세요
+
+이 파일은 GitHub Achievements 테스트를 위해 생성되었습니다.


### PR DESCRIPTION
## 변경사항 설명
GitHub Achievements(배지)에 대한 정보를 담은 마크다운 파일을 추가합니다.

## 내용
- 인기 있는 배지 목록
- 배지 획득 팁

## 목적
GitHub 배지 획득을 위한 실험적 PR입니다.